### PR TITLE
Update Voron_1_SKR_14_Config.cfg

### DIFF
--- a/Firmware/klipper_configurations/SKR_1.4/Voron_1_SKR_14_Config.cfg
+++ b/Firmware/klipper_configurations/SKR_1.4/Voron_1_SKR_14_Config.cfg
@@ -172,7 +172,7 @@ position_endstop: -0.5
 
 ##--------------------------------------------------------------------
 position_min: -5
-homing_speed: 15.0
+homing_speed: 8.0 # Leadscrews are slower than 2.4, 10 is a recommended max.
 second_homing_speed: 3.0
 homing_retract_dist: 3.0
 


### PR DESCRIPTION
Lowered homing speed as the default is from 2.4 and leadscrews are slower