### PR TITLE
Uses math to determine PRINT_END safe direction and proper parking

### DIFF
--- a/Firmware/klipper_configurations/SKR_1.4/Voron_1_SKR_14_Config.cfg
+++ b/Firmware/klipper_configurations/SKR_1.4/Voron_1_SKR_14_Config.cfg
@@ -506,20 +506,47 @@ gcode:
     M117 Printing...
 
 [gcode_macro PRINT_END]
-#   Use PRINT_END for the slicer ending script - PLEASE CUSTOMISE THE SCRIPT FO$
+#   Use PRINT_END for the slicer ending script
 gcode:
-    M400                           ; wait for buffer to clear
-    G92 E0                         ; zero the extruder
-    G1 E-4.0 F3600                 ; retract
-    G91                            ; relative positioning
-    G0 Z1.00 X20.0 Y20.0 F20000    ; move nozzle to remove stringing
-    M104 S0                        ; turn off hotend
-    M140 S0                        ; turn off bed
-    M106 S0                        ; turn off fan
-    G1 Z2 F3000                    ; move nozzle up 2mm
-    G90                            ; absolute positioning
-    G0  X175 Y240 F3600            ; park nozzle at rear
-    M117 Finished!                 ; display message
+    #   Get Boundaries
+    {% set max_x = printer.configfile.config["stepper_x"]["position_max"]|float %}
+    {% set max_y = printer.configfile.config["stepper_y"]["position_max"]|float %}
+    {% set max_z = printer.configfile.config["stepper_z"]["position_max"]|float %}
+    
+    #   Check end position to determine safe directions to move
+    {% if printer.toolhead.position.x < (max_x - 20) %}
+        {% set x_safe = 20.0 %}
+    {% else %}
+        {% set x_safe = -20.0 %}
+    {% endif %}
+
+    {% if printer.toolhead.position.y < (max_y - 20) %}
+        {% set y_safe = 20.0 %}
+    {% else %}
+        {% set y_safe = -20.0 %}
+    {% endif %}
+
+    {% if printer.toolhead.position.z < (max_z - 2) %}
+        {% set z_safe = 2.0 %}
+    {% else %}
+        {% set z_safe = max_z - printer.toolhead.position.z %}
+    {% endif %}
+    
+    #  Commence PRINT_END
+    M400                             ; wait for buffer to clear
+    G92 E0                           ; zero the extruder
+    G1 E-4.0 F3600                   ; retract
+    G91                              ; relative positioning
+    G0 Z{z_safe} F3600               ; move nozzle up
+    G0 X{x_safe} Y{y_safe} F20000    ; move nozzle to remove stringing    
+      
+    M104 S0                          ; turn off hotend
+    M140 S0                          ; turn off bed
+    M106 S0                          ; turn off fan
+    G90                              ; absolute positioning
+    G0 X{max_x / 2} Y{max_y} F3600   ; park nozzle at rear
+    M117 Finished!
+
 
 ## 	Thermistor Types
 ##   "EPCOS 100K B57560G104F"


### PR DESCRIPTION
Check to see if the final nozzle move at PRINT_END is within the printer boundaries to avoid errors.  Also properly parks the toolhead centered and all the way back.