### PR TITLE
color_order_GRB is no longer a supported option

### DIFF
--- a/Firmware/klipper_configurations/SKR_1.4/Voron_1_SKR_14_Config.cfg
+++ b/Firmware/klipper_configurations/SKR_1.4/Voron_1_SKR_14_Config.cfg
@@ -405,7 +405,6 @@ gcode:
 #initial_RED: 0.1
 #initial_GREEN: 0.5
 #initial_BLUE: 0.0
-#color_order_GRB: False
 
 ##	Set RGB values on boot up for each Neopixel. 
 ##	Index 1 = display, Index 2 and 3 = Knob


### PR DESCRIPTION
As of 29 October 2020, The klipper master branch no longer supports the color_order_GRB parameter - Per the changelog here: https://github.com/KevinOConnor/klipper/blob/master/docs/Config_Changes.md

This generates a klipper error and it will not successfully load the configuration.