### PR TITLE
Remove V2 references from the firmware

### DIFF
--- a/Firmware/klipper_configurations/SKR_1.4/Voron_1_SKR_14_Config.cfg
+++ b/Firmware/klipper_configurations/SKR_1.4/Voron_1_SKR_14_Config.cfg
@@ -5,8 +5,7 @@
 ## Thermistor types						[extruder] and [heater_bed] sections - See 'sensor types' list at end of file
 ## Z Endstop Switch location			[homing_override] section
 ## Z Endstop Switch  offset for Z0		[stepper_z] section
-## Probe points							[quad_gantry_level] section
-## Min & Max gantry corner postions		[quad_gantry_level] section
+## Probe points							[z_tilt] section
 ## PID tune								[extruder] and [heater_bed] sections
 ## Fine tune E steps					[extruder] section
 
@@ -274,9 +273,9 @@ pid_kd: 363.769
 
 [probe]
 ##	Inductive Probe
-##	This probe is not used for Z height, only Quad Gantry Leveling
+##	This probe is not used for Z height, only Z Tilt Adjustment
 ##	Z_MAX on mcu_z
-##	If your probe is NO instead of NC, add change pin to !z:P0.10
+##	If your probe is NO instead of NC, add change pin to !P0.10
 pin: ^P0.10
 x_offset: 0
 y_offset: 25.0
@@ -363,10 +362,6 @@ gcode:
    	#G0 X150 Y150 Z30 F3600
 #--------------------------------------------------------------------
 
-   
-[z_tilt]
-
-
 #####################################################################
 # 	Displays
 #####################################################################
@@ -432,7 +427,7 @@ points:
 	#30, 155
 	#220, 155
 speed: 300
-horizontal_move_z: 4
+horizontal_move_z: 10
 retries: 5
 retry_tolerance: 0.0075
 


### PR DESCRIPTION
Removed some leftover V2 references. Also increased the default horizontal_move_z in z_tilt, since slanted beds can cancel the z_tilt procedure more easily on 4