### PR TITLE
Update SKR 1.4 config

### DIFF
--- a/Firmware/klipper_configurations/SKR_1.4/Voron_1_SKR_14_Config.cfg
+++ b/Firmware/klipper_configurations/SKR_1.4/Voron_1_SKR_14_Config.cfg
@@ -1,12 +1,11 @@
-## Voron Design VORON2 250/300/350mm SKR 1.4 TMC2209 UART config
+## Voron Design VORON1.8 250/300mm SKR 1.4 TMC2208/2209 UART config
 
 ## *** THINGS TO CHANGE/CHECK: ***
 ## MCU paths							[mcu] section
 ## Thermistor types						[extruder] and [heater_bed] sections - See 'sensor types' list at end of file
 ## Z Endstop Switch location			[homing_override] section
 ## Z Endstop Switch  offset for Z0		[stepper_z] section
-## Probe points							[quad_gantry_level] section
-## Min & Max gantry corner postions		[quad_gantry_level] section
+## Probe points							[z_tilt] section
 ## PID tune								[extruder] and [heater_bed] sections
 ## Fine tune E steps					[extruder] section
 
@@ -172,7 +171,7 @@ position_endstop: -0.5
 
 ##--------------------------------------------------------------------
 position_min: -5
-homing_speed: 15.0
+homing_speed: 8.0 # Leadscrews are slower than 2.4, 10 is a recommended max.
 second_homing_speed: 3.0
 homing_retract_dist: 3.0
 
@@ -274,9 +273,9 @@ pid_kd: 363.769
 
 [probe]
 ##	Inductive Probe
-##	This probe is not used for Z height, only Quad Gantry Leveling
+##	This probe is not used for Z height, only Z Tilt Adjustment
 ##	Z_MAX on mcu_z
-##	If your probe is NO instead of NC, add change pin to !z:P0.10
+##	If your probe is NO instead of NC, add change pin to !P0.10
 pin: ^P0.10
 x_offset: 0
 y_offset: 25.0
@@ -363,10 +362,6 @@ gcode:
    	#G0 X150 Y150 Z30 F3600
 #--------------------------------------------------------------------
 
-   
-[z_tilt]
-
-
 #####################################################################
 # 	Displays
 #####################################################################
@@ -405,7 +400,7 @@ gcode:
 #initial_RED: 0.1
 #initial_GREEN: 0.5
 #initial_BLUE: 0.0
-#color_order_GRB: False
+#color_order: RGB
 
 ##	Set RGB values on boot up for each Neopixel. 
 ##	Index 1 = display, Index 2 and 3 = Knob
@@ -432,7 +427,7 @@ points:
 	#30, 155
 	#220, 155
 speed: 300
-horizontal_move_z: 4
+horizontal_move_z: 10
 retries: 5
 retry_tolerance: 0.0075
 
@@ -506,20 +501,47 @@ gcode:
     M117 Printing...
 
 [gcode_macro PRINT_END]
-#   Use PRINT_END for the slicer ending script - PLEASE CUSTOMISE THE SCRIPT FO$
+#   Use PRINT_END for the slicer ending script
 gcode:
-    M400                           ; wait for buffer to clear
-    G92 E0                         ; zero the extruder
-    G1 E-4.0 F3600                 ; retract
-    G91                            ; relative positioning
-    G0 Z1.00 X20.0 Y20.0 F20000    ; move nozzle to remove stringing
-    M104 S0                        ; turn off hotend
-    M140 S0                        ; turn off bed
-    M106 S0                        ; turn off fan
-    G1 Z2 F3000                    ; move nozzle up 2mm
-    G90                            ; absolute positioning
-    G0  X175 Y240 F3600            ; park nozzle at rear
-    M117 Finished!                 ; display message
+    #   Get Boundaries
+    {% set max_x = printer.configfile.config["stepper_x"]["position_max"]|float %}
+    {% set max_y = printer.configfile.config["stepper_y"]["position_max"]|float %}
+    {% set max_z = printer.configfile.config["stepper_z"]["position_max"]|float %}
+    
+    #   Check end position to determine safe directions to move
+    {% if printer.toolhead.position.x < (max_x - 20) %}
+        {% set x_safe = 20.0 %}
+    {% else %}
+        {% set x_safe = -20.0 %}
+    {% endif %}
+
+    {% if printer.toolhead.position.y < (max_y - 20) %}
+        {% set y_safe = 20.0 %}
+    {% else %}
+        {% set y_safe = -20.0 %}
+    {% endif %}
+
+    {% if printer.toolhead.position.z < (max_z - 2) %}
+        {% set z_safe = 2.0 %}
+    {% else %}
+        {% set z_safe = max_z - printer.toolhead.position.z %}
+    {% endif %}
+    
+    #  Commence PRINT_END
+    M400                             ; wait for buffer to clear
+    G92 E0                           ; zero the extruder
+    G1 E-4.0 F3600                   ; retract
+    G91                              ; relative positioning
+    G0 Z{z_safe} F3600               ; move nozzle up
+    G0 X{x_safe} Y{y_safe} F20000    ; move nozzle to remove stringing    
+      
+    M104 S0                          ; turn off hotend
+    M140 S0                          ; turn off bed
+    M106 S0                          ; turn off fan
+    G90                              ; absolute positioning
+    G0 X{max_x / 2} Y{max_y} F3600   ; park nozzle at rear
+    M117 Finished!
+
 
 ## 	Thermistor Types
 ##   "EPCOS 100K B57560G104F"


### PR DESCRIPTION
Lowered homing speed as the default is from 2.4 and leadscrews are slower

Fix title and description

Uses math to determine PRINT_END safe direction and proper parking

Fix LCD color option

Remove V2 references and objects from the firmware