### PR TITLE
Update SKR configs

### DIFF
--- a/Firmware/klipper_configurations/SKR_1.3/Voron_1_SKR_13_Config.cfg
+++ b/Firmware/klipper_configurations/SKR_1.3/Voron_1_SKR_13_Config.cfg
@@ -1,14 +1,14 @@
-## Voron Design VORON1.8 250/300mm SKR 1.3 TMC2208/2209 UART config
+## Voron Design VORON1.8 250/300mm SKR 1.3 TMC2209 UART config
 
 ## *** THINGS TO CHANGE/CHECK: ***
 ## MCU paths							[mcu] section
 ## Thermistor types						[extruder] and [heater_bed] sections - See 'sensor types' list at end of file
 ## Z Endstop Switch location			[homing_override] section
 ## Z Endstop Switch  offset for Z0		[stepper_z] section
-## Leadscrew type settings for Z (step_distance for both z steppers)
+## Leadscrew type settings for Z 		Rotation_Distance for both steppers
 ## Probe points							[z_tilt] section
 ## PID tune								[extruder] and [heater_bed] sections
-## Enable Heated Bed    [Heater_bed] section
+## Enable Heated Bed    				[Heater_bed] section
 ## Fine tune E steps					[extruder] section
 
 ##========================== SKR1.3 Pin Definitions ========================
@@ -56,21 +56,17 @@
 ##===================================================================
 
 [mcu]
-##	MCU for X/Y/E steppers main MCU
-##	[X in X] - B Motor
-##	[Y in Y] - A Motor
-##	[E in E0] - Extruder
 ##	Obtain definition by "ls -l /dev/serial/by-id/" then unplug to verify
 ##--------------------------------------------------------------------
-serial: /dev/serial/by-id/usb-Klipper_stm32f446xx_480058000851363131363530-if00
+serial: /dev/serial/by-id/usb-Klipper_lpc1768_0310000F43181EAEAED31252841E00F5-if00
 ##--------------------------------------------------------------------
 
 [printer]
 kinematics: corexy
 max_velocity: 300  
-max_accel: 3000    			#Max 4000
-max_z_velocity: 15 			#Max 15 for 12V TMC Drivers, can increase for 24V
-max_z_accel: 50   			#Max ?
+max_accel: 3000
+max_z_velocity: 15
+max_z_accel: 50	
 square_corner_velocity: 5.0  
 
 #####################################################################
@@ -78,7 +74,7 @@ square_corner_velocity: 5.0
 #####################################################################
 
 [stepper_x]
-##	Connected to X
+##	Connected to X (B Motor)
 step_pin: P2.2
 dir_pin: !P2.6
 enable_pin: !P2.1
@@ -98,12 +94,11 @@ position_min: 0
 #position_max: 300
 
 ##--------------------------------------------------------------------
-homing_speed: 25   #Max 100
+homing_speed: 25   				#Max 100
 homing_retract_dist: 5
 homing_positive_dir: true
 
-##	Make sure to update below for your relevant driver (2208 or 2209)
-[tmcXXXX stepper_x]
+[tmc2209 stepper_x]
 uart_pin: P1.17
 interpolate: True
 run_current: 0.9
@@ -112,7 +107,7 @@ sense_resistor: 0.110
 stealthchop_threshold: 0
 
 [stepper_y]
-##	Connected to Y on mcu_xye (A Motor)
+##	Connected to Y (A Motor)
 step_pin: P0.19
 dir_pin: !P0.20
 enable_pin: !P2.8
@@ -132,12 +127,11 @@ position_min: 0
 #position_max: 300
 
 ##--------------------------------------------------------------------
-homing_speed: 25  #Max 100
+homing_speed: 25  				#Max 100
 homing_retract_dist: 5
 homing_positive_dir: true
 
-##	Make sure to update below for your relevant driver (2208 or 2209)
-[tmcXXXX stepper_y]
+[tmc2209 stepper_y]
 uart_pin: P1.15
 interpolate: True
 run_current: 0.9
@@ -149,7 +143,7 @@ stealthchop_threshold: 0
 # 	Z Stepper Settings
 #####################################################################
 
-## Z0 Stepper - Left
+## Z0 Stepper - Left Z Motor
 ## Z Stepper Socket
 [stepper_z]
 step_pin: P0.22
@@ -178,8 +172,7 @@ homing_speed: 8.0 # Leadscrews are slower than 2.4, 10 is a recommended max.
 second_homing_speed: 3.0
 homing_retract_dist: 3.0
 
-##	Make sure to update below for your relevant driver (2208 or 2209)
-[tmcXXXX stepper_z]
+[tmc2209 stepper_z]
 uart_pin: P1.10
 interpolate: true
 run_current: 0.7
@@ -198,8 +191,7 @@ rotation_distance: 8
 microsteps: 16
 full_steps_per_rotation: 200	#200 for 1.8 degree, 400 for 0.9 degree
 
-##	Make sure to update below for your relevant driver (2208 or 2209)
-[tmcXXXX stepper_z1]
+[tmc2209 stepper_z1]
 uart_pin: P1.8
 interpolate: true
 run_current: 0.7
@@ -242,10 +234,9 @@ pressure_advance: 0.05
 pressure_advance_smooth_time: 0.040
 
 ##	E1 on MCU
-##	Make sure to update below for your relevant driver (2208 or 2209)
-[tmcXXXX extruder]
+[tmc2209 extruder]
 uart_pin: P1.1
-interpolate: false
+interpolate: true
 run_current: 0.5
 hold_current: 0.4
 sense_resistor: 0.110
@@ -257,8 +248,8 @@ stealthchop_threshold: 0
 
 [heater_bed]
 ##	SSR Pin - Z board, Servo Pin
-heater_pin:    P2.0
-sensor_type: NTC 100K MGB18-104F39050L32
+heater_pin: P2.0
+sensor_type: NTC 100K beta 3950
 sensor_pin: P0.23
 ##	Adjust Max Power so your heater doesn't warp your bed
 ##  A good starting point is 0.4 W/cm^2
@@ -304,7 +295,7 @@ heater_temp: 50.0
 #fan_speed: 1.0
 
 [fan]
-##	Print Cooling Fan - XYE board, Fan Pin
+##	Print Cooling Fan - Fan Pin
 pin: P2.3
 kick_start_time: 0.5
 ##	Depending on your fan, you may need to increase this value
@@ -313,7 +304,7 @@ kick_start_time: 0.5
 off_below: 0.10
 
 #[heater_fan exhaust_fan]
-##	Exhaust fan - Bed Connector
+##	Exhaust Fan - Bed Connector (Optional)
 #pin: P2.5
 #max_power: 1.0
 #shutdown_speed: 0.0
@@ -323,14 +314,12 @@ off_below: 0.10
 #fan_speed: 1.0
 
 #####################################################################
-# 	LED Control
+# 	LED Control (Optional)
 #####################################################################
 
 #[output_pin caselight]
-# chamber lighting
+# Chamber Lighting - Bed Connector (Optional)
 #pin: P2.5
-#max_power: 1.0
-#kick_start_time: 0.5
 #pwm:true
 #shutdown_value: 0
 #value:100
@@ -542,6 +531,6 @@ gcode:
 ##   "ATC Semitec 104GT-2"
 ##   "NTC 100K beta 3950"
 ##   "Honeywell 100K 135-104LAG-J01"
-##   "NTC 100K MGB18-104F39050L32" (Keenovo Heater Pad)
+##   "NTC 100K MGB18-104F39050L32"
 ##   "AD595"
 ##   "PT100 INA826"

--- a/Firmware/klipper_configurations/SKR_1.3/Voron_1_SKR_13_Config.cfg
+++ b/Firmware/klipper_configurations/SKR_1.3/Voron_1_SKR_13_Config.cfg
@@ -184,7 +184,7 @@ stealthchop_threshold: 0
 ##	E0 Stepper Socket
 [stepper_z1]
 step_pin: P2.13
-dir_pin: !P0.11
+dir_pin: P0.11
 enable_pin: !P2.12
 ## Remember to mirror these changes in stepper_z! (there are two motors)
 rotation_distance: 8			

--- a/Firmware/klipper_configurations/SKR_1.3/Voron_1_SKR_13_Config.cfg
+++ b/Firmware/klipper_configurations/SKR_1.3/Voron_1_SKR_13_Config.cfg
@@ -180,7 +180,7 @@ hold_current: 0.5
 sense_resistor: 0.110
 stealthchop_threshold: 0
 
-##	Z1 Stepper - Right
+##	Z1 Stepper - Right Z Motor
 ##	E0 Stepper Socket
 [stepper_z1]
 step_pin: P2.13

--- a/Firmware/klipper_configurations/SKR_1.4/Voron_1_SKR_14_Config.cfg
+++ b/Firmware/klipper_configurations/SKR_1.4/Voron_1_SKR_14_Config.cfg
@@ -1,14 +1,14 @@
-## Voron Design VORON1.8 250/300mm SKR 1.4 TMC2208/2209 UART config
+## Voron Design VORON1.8 250/300mm SKR 1.4 TMC2209 UART config
 
 ## *** THINGS TO CHANGE/CHECK: ***
 ## MCU paths							[mcu] section
 ## Thermistor types						[extruder] and [heater_bed] sections - See 'sensor types' list at end of file
 ## Z Endstop Switch location			[homing_override] section
 ## Z Endstop Switch  offset for Z0		[stepper_z] section
-## Leadscrew type settings for Z (step_distance for both z steppers)
+## Leadscrew type settings for Z 		Rotation_Distance for both steppers
 ## Probe points							[z_tilt] section
 ## PID tune								[extruder] and [heater_bed] sections
-## Enable Heated Bed    [Heater_bed] section
+## Enable Heated Bed    				[Heater_bed] section
 ## Fine tune E steps					[extruder] section
 
 ##========================== Pin Definitions ========================
@@ -56,21 +56,17 @@
 ##===================================================================
 
 [mcu]
-##	MCU for X/Y/E steppers main MCU
-##	[X in X] - B Motor
-##	[Y in Y] - A Motor
-##	[E in E0] - Extruder
 ##	Obtain definition by "ls -l /dev/serial/by-id/" then unplug to verify
 ##--------------------------------------------------------------------
-serial: /dev/serial/by-id/usb-Klipper_stm32f446xx_480058000851363131363530-if00
+serial: /dev/serial/by-id/usb-Klipper_lpc1768_0310000F43181EAEAED31252841E00F5-if00
 ##--------------------------------------------------------------------
 
 [printer]
 kinematics: corexy
 max_velocity: 300  
-max_accel: 3000    			#Max 4000
-max_z_velocity: 15 			#Max 15 for 12V TMC Drivers, can increase for 24V
-max_z_accel: 50   			#Max ?
+max_accel: 3000
+max_z_velocity: 15
+max_z_accel: 50
 square_corner_velocity: 5.0  
 
 #####################################################################
@@ -78,7 +74,7 @@ square_corner_velocity: 5.0
 #####################################################################
 
 [stepper_x]
-##	Connected to X
+##	Connected to X (B Motor)
 step_pin: P2.2
 dir_pin: !P2.6
 enable_pin: !P2.1
@@ -98,12 +94,11 @@ position_min: 0
 #position_max: 300
 
 ##--------------------------------------------------------------------
-homing_speed: 25   #Max 100
+homing_speed: 25   				#Max 100
 homing_retract_dist: 5
 homing_positive_dir: true
 
-##	Make sure to update below for your relevant driver (2208 or 2209)
-[tmcXXXX stepper_x]
+[tmc2209 stepper_x]
 uart_pin: P1.10
 interpolate: True
 run_current: 0.9
@@ -112,7 +107,7 @@ sense_resistor: 0.110
 stealthchop_threshold: 0
 
 [stepper_y]
-##	Connected to Y on mcu_xye (A Motor)
+##	Connected to Y (A Motor)
 step_pin: P0.19
 dir_pin: !P0.20
 enable_pin: !P2.8
@@ -132,12 +127,11 @@ position_min: 0
 #position_max: 300
 
 ##--------------------------------------------------------------------
-homing_speed: 25  #Max 100
+homing_speed: 25  				#Max 100
 homing_retract_dist: 5
 homing_positive_dir: true
 
-##	Make sure to update below for your relevant driver (2208 or 2209)
-[tmcXXXX stepper_y]
+[tmc2209 stepper_y]
 uart_pin: P1.9
 interpolate: True
 run_current: 0.9
@@ -149,7 +143,7 @@ stealthchop_threshold: 0
 # 	Z Stepper Settings
 #####################################################################
 
-## Z0 Stepper - Left
+## Z0 Stepper - Left Z Motor
 ## Z Stepper Socket
 [stepper_z]
 step_pin: P0.22
@@ -178,8 +172,7 @@ homing_speed: 8.0 # Leadscrews are slower than 2.4, 10 is a recommended max.
 second_homing_speed: 3.0
 homing_retract_dist: 3.0
 
-##	Make sure to update below for your relevant driver (2208 or 2209)
-[tmcXXXX stepper_z]
+[tmc2209 stepper_z]
 uart_pin: P1.8
 interpolate: true
 run_current: 0.7
@@ -198,8 +191,7 @@ rotation_distance: 8
 microsteps: 16
 full_steps_per_rotation: 200	#200 for 1.8 degree, 400 for 0.9 degree
 
-##	Make sure to update below for your relevant driver (2208 or 2209)
-[tmcXXXX stepper_z1]
+[tmc2209 stepper_z1]
 uart_pin: P1.4
 interpolate: true
 run_current: 0.7
@@ -242,10 +234,9 @@ pressure_advance: 0.05
 pressure_advance_smooth_time: 0.040
 
 ##	E1 on MCU
-##	Make sure to update below for your relevant driver (2208 or 2209)
-[tmcXXXX extruder]
+[tmc2209 extruder]
 uart_pin: P1.1
-interpolate: false
+interpolate: true
 run_current: 0.5
 hold_current: 0.4
 sense_resistor: 0.110
@@ -258,7 +249,7 @@ stealthchop_threshold: 0
 [heater_bed]
 ##	SSR Pin - Z board, Servo Pin
 heater_pin: P1.24
-sensor_type: NTC 100K MGB18-104F39050L32
+sensor_type: NTC 100K beta 3950
 sensor_pin: P0.25
 ##	Adjust Max Power so your heater doesn't warp your bed
 ##  A good starting point is 0.4 W/cm^2
@@ -304,7 +295,7 @@ heater_temp: 50.0
 #fan_speed: 1.0
 
 [fan]
-##	Print Cooling Fan - XYE board, Fan Pin
+##	Print Cooling Fan - Fan Pin
 pin: P2.3
 kick_start_time: 0.5
 ##	Depending on your fan, you may need to increase this value
@@ -313,7 +304,7 @@ kick_start_time: 0.5
 off_below: 0.10
 
 #[heater_fan exhaust_fan]
-##	Exhaust fan - Bed Connector
+##	Exhaust Fan - Bed Connector (Optional)
 #pin: P2.5
 #max_power: 1.0
 #shutdown_speed: 0.0
@@ -323,15 +314,13 @@ off_below: 0.10
 #fan_speed: 1.0
 
 #####################################################################
-# 	LED Control
+# 	LED Control (Optional)
 #####################################################################
 
 #[output_pin caselight]
-# chamber lighting
+# Chamber Lighting - Bed Connector (Optional)
 #pin: P2.5
-#max_power: 1.0
-#kick_start_time: 0.5
-#pwm:true
+#pwm: true
 #shutdown_value: 0
 #value:100
 #cycle_time: 0.01
@@ -542,6 +531,6 @@ gcode:
 ##   "ATC Semitec 104GT-2"
 ##   "NTC 100K beta 3950"
 ##   "Honeywell 100K 135-104LAG-J01"
-##   "NTC 100K MGB18-104F39050L32" (Keenovo Heater Pad)
+##   "NTC 100K MGB18-104F39050L32"
 ##   "AD595"
 ##   "PT100 INA826"

--- a/Firmware/klipper_configurations/SKR_1.4/Voron_1_SKR_14_Config.cfg
+++ b/Firmware/klipper_configurations/SKR_1.4/Voron_1_SKR_14_Config.cfg
@@ -147,7 +147,7 @@ stealthchop_threshold: 0
 ## Z Stepper Socket
 [stepper_z]
 step_pin: P0.22
-dir_pin: !P2.11
+dir_pin: P2.11
 enable_pin: !P0.21
 
 # Rotation Distance for TR8x8 = 8, TR8x4 = 4, TR8x2 = 2
@@ -184,7 +184,7 @@ stealthchop_threshold: 0
 ##	E0 Stepper Socket
 [stepper_z1]
 step_pin: P2.13
-dir_pin: !P0.11
+dir_pin: P0.11
 enable_pin: !P2.12
 ## Remember to mirror these changes in stepper_z! (there are two motors)
 rotation_distance: 8			

--- a/Firmware/klipper_configurations/SKR_1.4/Voron_1_SKR_14_Config.cfg
+++ b/Firmware/klipper_configurations/SKR_1.4/Voron_1_SKR_14_Config.cfg
@@ -180,7 +180,7 @@ hold_current: 0.5
 sense_resistor: 0.110
 stealthchop_threshold: 0
 
-##	Z1 Stepper - Right
+##	Z1 Stepper - Right Z Motor
 ##	E0 Stepper Socket
 [stepper_z1]
 step_pin: P2.13


### PR DESCRIPTION
-Add 2209 as default option instead of forcing the choice for 2208 or 2209
-Update default bed thermistor to the correct b3950 version (per Keenovo documentation)
-Update default "by-id" to have the correct MCU (previously was a stm example)
-Remove V2 references to multi MCUs
-Set extruder to interpolate: true
-Update Chamber Lighting section
-Fix inverted Z direction on one motor