### PR TITLE
Adds heat bed and extruder commands to PRINT_START

### DIFF
--- a/Firmware/klipper_configurations/SKR_1.3/Voron_1_SKR_13_Config.cfg
+++ b/Firmware/klipper_configurations/SKR_1.3/Voron_1_SKR_13_Config.cfg
@@ -473,6 +473,25 @@ relative_reference_index: 12
 [gcode_macro PRINT_START]
 #   Use PRINT_START for the slicer starting script - PLEASE CUSTOMISE THE SCRIPT
 gcode:
+    # Begin heating bed and extruder
+    
+    # In your slicer Start G-code, issue a PRINT_START followed by EXTRUDER_TEMP and BED_TEMP with their substitution variables.
+
+    # Examples:
+    # PrusaSlicer / SuperSlicer:  PRINT_START EXTRUDER_TEMP=[first_layer_temperature] BED_TEMP=[first_layer_bed_temperature]
+    # Cura: PRINT_START EXTRUDER_TEMP={material_print_temperature} BED_TEMP={material_bed_temperature}
+    
+    # Uncomment if you want to set a default bed temp in case your slicer doesn't pass it
+    # default_parameter_BED: 60
+
+    # Uncomment if you want to set a default extruder temp in case your slicer doesn't pass it
+    # default_parameter_EXTRUDER: 200
+
+    M140 S{BED_TEMP} ; set bed temperature
+    M190 S{BED_TEMP} ; set bed temperature and wait for it to be reached
+    M104 S{EXTRUDER_TEMP} ; set extruder temperature
+    M109 S{EXTRUDER_TEMP} ; set temperature and wait for it to be reached
+    
     M117 Homing...                 ; display message
     G28 Y0 X0 Z0
     Z_TILT_ADJUST

--- a/Firmware/klipper_configurations/SKR_1.3/Voron_1_SKR_13_Config.cfg
+++ b/Firmware/klipper_configurations/SKR_1.3/Voron_1_SKR_13_Config.cfg
@@ -482,10 +482,10 @@ gcode:
     # Cura: PRINT_START EXTRUDER_TEMP={material_print_temperature} BED_TEMP={material_bed_temperature}
     
     # Uncomment if you want to set a default bed temp in case your slicer doesn't pass it
-    # default_parameter_BED: 60
+    # default_parameter_BED_TEMP: 60
 
     # Uncomment if you want to set a default extruder temp in case your slicer doesn't pass it
-    # default_parameter_EXTRUDER: 200
+    # default_parameter_EXTRUDER_TEMP: 200
 
     M140 S{BED_TEMP} ; set bed temperature
     M190 S{BED_TEMP} ; set bed temperature and wait for it to be reached

--- a/Firmware/klipper_configurations/SKR_1.4/Voron_1_SKR_14_Config.cfg
+++ b/Firmware/klipper_configurations/SKR_1.4/Voron_1_SKR_14_Config.cfg
@@ -473,6 +473,25 @@ relative_reference_index: 12
 [gcode_macro PRINT_START]
 #   Use PRINT_START for the slicer starting script - PLEASE CUSTOMISE THE SCRIPT
 gcode:
+    # Begin heating bed and extruder
+    
+    # In your slicer Start G-code, issue a PRINT_START followed by EXTRUDER_TEMP and BED_TEMP with their substitution variables.
+
+    # Examples:
+    # PrusaSlicer / SuperSlicer:  PRINT_START EXTRUDER_TEMP=[first_layer_temperature] BED_TEMP=[first_layer_bed_temperature]
+    # Cura: PRINT_START EXTRUDER_TEMP={material_print_temperature} BED_TEMP={material_bed_temperature}
+    
+    # Uncomment if you want to set a default bed temp in case your slicer doesn't pass it
+    # default_parameter_BED: 60
+
+    # Uncomment if you want to set a default extruder temp in case your slicer doesn't pass it
+    # default_parameter_EXTRUDER: 200
+
+    M140 S{BED_TEMP} ; set bed temperature
+    M190 S{BED_TEMP} ; set bed temperature and wait for it to be reached
+    M104 S{EXTRUDER_TEMP} ; set extruder temperature
+    M109 S{EXTRUDER_TEMP} ; set temperature and wait for it to be reached 
+    
     M117 Homing...                 ; display message
     G28 Y0 X0 Z0
     Z_TILT_ADJUST

--- a/Firmware/klipper_configurations/SKR_1.4/Voron_1_SKR_14_Config.cfg
+++ b/Firmware/klipper_configurations/SKR_1.4/Voron_1_SKR_14_Config.cfg
@@ -482,10 +482,10 @@ gcode:
     # Cura: PRINT_START EXTRUDER_TEMP={material_print_temperature} BED_TEMP={material_bed_temperature}
     
     # Uncomment if you want to set a default bed temp in case your slicer doesn't pass it
-    # default_parameter_BED: 60
+    # default_parameter_BED_TEMP: 60
 
     # Uncomment if you want to set a default extruder temp in case your slicer doesn't pass it
-    # default_parameter_EXTRUDER: 200
+    # default_parameter_EXTRUDER_TEMP: 200
 
     M140 S{BED_TEMP} ; set bed temperature
     M190 S{BED_TEMP} ; set bed temperature and wait for it to be reached


### PR DESCRIPTION
Updates both the SKR 1.3 and SKR 1.4 `printer.cfg` and includes commands to begin heating the extruder and bed in the `PRINT_START` macro.