### PR TITLE
Fix comment for pin definition of NO probes

### DIFF
--- a/Firmware/klipper_configurations/SKR_1.3/Voron_1_SKR_13_Config.cfg
+++ b/Firmware/klipper_configurations/SKR_1.3/Voron_1_SKR_13_Config.cfg
@@ -268,7 +268,7 @@ pid_kd: 363.769
 [probe]
 ##	Inductive Probe
 ##	This probe is not used for Z height, only Z Tilt Adjustment
-##	If your probe is NO instead of NC, add change pin to !P1.24
+##	If your probe is NO instead of NC, change pin to !^P1.24
 pin: ^P1.24
 x_offset: 0
 y_offset: 25.0

--- a/Firmware/klipper_configurations/SKR_1.4/Voron_1_SKR_14_Config.cfg
+++ b/Firmware/klipper_configurations/SKR_1.4/Voron_1_SKR_14_Config.cfg
@@ -268,7 +268,7 @@ pid_kd: 363.769
 [probe]
 ##	Inductive Probe
 ##	This probe is not used for Z height, only Z Tilt Adjustment
-##	If your probe is NO instead of NC, add change pin to !P0.10
+##	If your probe is NO instead of NC, change pin to !^P0.10
 pin: ^P0.10
 x_offset: 0
 y_offset: 25.0


### PR DESCRIPTION
The pull-up should also be active for NO probes.