### PR TITLE
Homing override fixes

### DIFF
--- a/Firmware/klipper_configurations/SKR_1.3/Voron_1_SKR_13_Config.cfg
+++ b/Firmware/klipper_configurations/SKR_1.3/Voron_1_SKR_13_Config.cfg
@@ -343,7 +343,7 @@ gcode:
    ##	XY Location of the Z Endstop Switch
    ##	Update X0 and Y0 to your values (such as X157, Y305) after going through
    ##	Z Endstop Pin Location Definition step.
-   G0 X0 Y0 F3600 
+   G0 X-10 Y-10 F3600 
    
    G28 Z
    G0 Z10 F1800

--- a/Firmware/klipper_configurations/SKR_1.3/Voron_1_SKR_13_Config.cfg
+++ b/Firmware/klipper_configurations/SKR_1.3/Voron_1_SKR_13_Config.cfg
@@ -341,7 +341,7 @@ gcode:
    G0 Z5 F600
    G28 X Y
    ##	XY Location of the Z Endstop Switch
-   ##	Update X0 and Y0 to your values (such as X157, Y305) after going through
+   ##	Update X and Y to your values (such as X157, Y305) after going through
    ##	Z Endstop Pin Location Definition step.
    G0 X-10 Y-10 F3600 
    

--- a/Firmware/klipper_configurations/SKR_1.4/Voron_1_SKR_14_Config.cfg
+++ b/Firmware/klipper_configurations/SKR_1.4/Voron_1_SKR_14_Config.cfg
@@ -343,7 +343,7 @@ gcode:
    ##	XY Location of the Z Endstop Switch
    ##	Update X0 and Y0 to your values (such as X157, Y305) after going through
    ##	Z Endstop Pin Location Definition step.
-   G0 X0 Y0 F3600 
+   G0 X-10 Y-10 F3600 
    
    G28 Z
    G0 Z10 F1800

--- a/Firmware/klipper_configurations/SKR_1.4/Voron_1_SKR_14_Config.cfg
+++ b/Firmware/klipper_configurations/SKR_1.4/Voron_1_SKR_14_Config.cfg
@@ -341,7 +341,7 @@ gcode:
    G0 Z5 F600
    G28 X Y
    ##	XY Location of the Z Endstop Switch
-   ##	Update X0 and Y0 to your values (such as X157, Y305) after going through
+   ##	Update X and Y to your values (such as X157, Y305) after going through
    ##	Z Endstop Pin Location Definition step.
    G0 X-10 Y-10 F3600 
    


### PR DESCRIPTION
Updatehoming_override default position to -10,-10 to cause error when not updated properly.